### PR TITLE
Remove non-async methods for favorites of resources

### DIFF
--- a/src/SmallsOnline.Web.Api/services/favorites-of/albums/CosmosDbService_GetFavoriteAlbumsOfYear.cs
+++ b/src/SmallsOnline.Web.Api/services/favorites-of/albums/CosmosDbService_GetFavoriteAlbumsOfYear.cs
@@ -5,15 +5,6 @@ namespace SmallsOnline.Web.Api.Services;
 
 public partial class CosmosDbService : ICosmosDbService
 {
-    public List<AlbumData> GetFavoriteAlbumsOfYear(string listYear)
-    {
-        Task<List<AlbumData>> getFromDbTask = Task.Run(async () => await GetFavoriteAlbumsOfYearAsync(listYear));
-
-        getFromDbTask.Wait();
-
-        return getFromDbTask.Result;
-    }
-
     /// <summary>
     /// Get the favorite albums for a specific year.
     /// </summary>

--- a/src/SmallsOnline.Web.Api/services/favorites-of/tracks/CosmosDbService_GetFavoriteTracksOfYear.cs
+++ b/src/SmallsOnline.Web.Api/services/favorites-of/tracks/CosmosDbService_GetFavoriteTracksOfYear.cs
@@ -5,15 +5,6 @@ namespace SmallsOnline.Web.Api.Services;
 
 public partial class CosmosDbService : ICosmosDbService
 {
-    public List<TrackData> GetFavoriteTracksOfYear(string listYear)
-    {
-        Task<List<TrackData>> getFromDbTask = Task.Run(async () => await GetFavoriteTracksOfYearAsync(listYear));
-
-        getFromDbTask.Wait();
-
-        return getFromDbTask.Result;
-    }
-
     /// <summary>
     /// Get the favorite tracks for a specific year.
     /// </summary>

--- a/src/SmallsOnline.Web.Api/services/interfaces/ICosmosDbService.cs
+++ b/src/SmallsOnline.Web.Api/services/interfaces/ICosmosDbService.cs
@@ -6,9 +6,6 @@ public interface ICosmosDbService
     Task<BlogEntry> GetBlogEntryAsync(string id);
     Task<int> GetBlogTotalPagesAsync();
 
-    List<AlbumData> GetFavoriteAlbumsOfYear(string listYear);
     Task<List<AlbumData>> GetFavoriteAlbumsOfYearAsync(string listYear);
-    
-    List<TrackData> GetFavoriteTracksOfYear(string listYear);
     Task<List<TrackData>> GetFavoriteTracksOfYearAsync(string listYear);
 }


### PR DESCRIPTION
The methods for getting favorite albums and tracks from the database synchronously have been removed since they are never used.